### PR TITLE
docs: fix simple typo, shoud -> should

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ However, you should know that you're using a compiler frontend, which can only w
 CommandLine Error: Option 'non-global-value-max-name-size' registered more than once! LLVM ERROR: inconsistency in registered CommandLine options
 ```
 
-In case you encounter this error, please use `CMakeLists_archlinux.txt` instead of `CMakeLists.txt` and it shoud go away. 
+In case you encounter this error, please use `CMakeLists_archlinux.txt` instead of `CMakeLists.txt` and it should go away. 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `should` rather than `shoud`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md